### PR TITLE
Fix fetch for python3.8 on LANL xc40 systems Backport

### DIFF
--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -11,8 +11,9 @@ import itertools
 import os.path
 import re
 
-from six import string_types
+#from six import string_types
 import six.moves.urllib.parse as urllib_parse
+from six import string_types
 
 import spack.util.path
 
@@ -151,21 +152,26 @@ def join(base_url, path, *extra, **kwargs):
         for x in itertools.chain((base_url, path), extra)]
     n = len(paths)
     last_abs_component = None
-    scheme = None
+    #scheme = None
+    scheme = ''
     for i in range(n - 1, -1, -1):
         obj = urllib_parse.urlparse(
-            paths[i], scheme=None, allow_fragments=False)
+#            paths[i], scheme=None, allow_fragments=False)
+            paths[i], scheme='', allow_fragments=False)
 
         scheme = obj.scheme
 
         # in either case the component is absolute
-        if scheme is not None or obj.path.startswith('/'):
-            if scheme is None:
+#        if scheme is not None or obj.path.startswith('/'):
+#            if scheme is None:
+        if scheme or obj.path.startswith('/'):
+            if not scheme:
                 # Without a scheme, we have to go back looking for the
                 # next-last component that specifies a scheme.
                 for j in range(i - 1, -1, -1):
                     obj = urllib_parse.urlparse(
-                        paths[j], scheme=None, allow_fragments=False)
+#                        paths[j], scheme=None, allow_fragments=False)
+                        paths[j], scheme='', allow_fragments=False)
 
                     if obj.scheme:
                         paths[i] = '{SM}://{NL}{PATH}'.format(


### PR DESCRIPTION
backporting fix for issue with cray-cnl7-py3.8 failures fetching packages: https://github.com/spack/spack/pull/24686

This bit me while trying to mitigate the security issue that came up with arm-forge https://git.hpc.lanl.gov/hpcsoft/tce-configs/-/commit/2acc9f85649f1bb2f3e820234b5266be8196a8db v21.x versions, and in attempt to deploy CI to cray-cnl7 xc40 systems, encountered this problem preventing the generation of the arm-forge/22.x binaries.  

That said, this is urgent, and this will get merged into tce_develop to remedy the block.