### PR TITLE
draft: Update bootstrap.py

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -250,6 +250,8 @@ class _BootstrapperBase(object):
 
     @property
     def mirror_url(self):
+        # hotfix for an issue Spack runs into when trying to bootstrap clingo without access to the internet
+        return "https://pe-serve.lanl.gov/spack-mirror"
         # Absolute paths
         if os.path.isabs(self.url):
             return spack.util.url.format(self.url)
@@ -264,7 +266,7 @@ class _BootstrapperBase(object):
     @property
     def mirror_scope(self):
         return spack.config.InternalConfigScope(
-            self.config_scope_name, {"mirrors:": {self.name: self.mirror_url}}
+            self.config_scope_name, {"mirrors": {self.name: self.mirror_url}}
         )
 
 


### PR DESCRIPTION
In the BootstrapBase class, Clingo fails to bootstrap if it doesn't have access to the internet because it's mirror_url property (specifically for bootstrapping) always returns github, instead of the contents of the mirrors.yaml. Current fix is a hotfix until we can figure out what the actual problem is.

the mirror_scope property also seems to have a typo in the key it references, "mirrors".